### PR TITLE
[WIP] Transformer appends linkerd outgoing port to external IP addr t…

### DIFF
--- a/charts/l5d-mesh/templates/configmap.yaml
+++ b/charts/l5d-mesh/templates/configmap.yaml
@@ -40,3 +40,28 @@ data:
         servers:
           - port: 4141
             ip: 0.0.0.0
+      - protocol: http
+        httpAccessLog: /dev/stdout
+        label: http-external-incoming
+        interpreter:
+          kind: io.l5d.namerd
+          dst: /$/inet/namerd.default.svc.cluster.local/4100
+          namespace: external
+          transformers:
+          - kind: io.l5d.port
+            port: 4143
+        servers:
+          - port: 4142
+            ip: 0.0.0.0
+      - protocol: http
+        httpAccessLog: /dev/stdout
+        label: http-external-outgoing
+        interpreter:
+          kind: io.l5d.namerd
+          dst: /$/inet/namerd.default.svc.cluster.local/4100
+          namespace: external
+          transformers:
+          - kind: io.l5d.k8s.localnode
+        servers:
+          - port: 4143
+            ip: 0.0.0.0

--- a/charts/l5d-mesh/templates/service.yaml
+++ b/charts/l5d-mesh/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: l5d
+spec:
+  type: NodePort
+  selector:
+    linkerd: sidecar
+  ports:
+    - port: 4140 
+      name: mesh
+    - port: 4142
+      name: http-external-incoming
+    - port: 4143
+      name: http-external-outgoing

--- a/charts/l5d-mesh/values.yaml
+++ b/charts/l5d-mesh/values.yaml
@@ -3,6 +3,8 @@ namespace: default
 exports:
   data:
     sidecar:
+      labels:
+        linkerd: sidecar
       volumes:
         - name: linkerd-config
           configMap:

--- a/templates/hello_deployment.yaml
+++ b/templates/hello_deployment.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ .Release.Name }}-{{ .Chart.Name }}-hello
   labels:
     app: {{ .Chart.Name }}-hello
-    linkerd: sidecar
     release: {{ .Release.Name }}
+{{ toYaml .Values.sidecar.labels | indent 4 }}
 spec:
   replicas: 3
   template:

--- a/templates/world_deployment.yaml
+++ b/templates/world_deployment.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ .Release.Name }}-{{ .Chart.Name }}-world
   labels:
     app: {{ .Chart.Name }}-world
-    linkerd: sidecar
     release: {{ .Release.Name }}
+{{ toYaml .Values.sidecar.labels | indent 4 }}
 spec:
   replicas: 3
   template:


### PR DESCRIPTION
…hat namerd resolved

Example:

When `curl localhost:4142 --header 'Host: www.google.co.jp'` . `Port` transformer transforms resolved address `216.58.197.227` append `4143` port. That cause resolved address unreachable.

```
pouring-angelfish-helloworld-mesh-hello-2190537245-wv185 linkerd E 0911 08:04:13.
787 UTC THREAD25 TraceId:fc7215ae5f9bbdf4: service failure: Failure(connection ti
med out: /216.58.197.227:4143 at remote address: /216.58.197.227:4143. Remote Inf
o: Not Available, flags=0x09) with RemoteInfo -> Upstream Address: /100.96.18.0:3
7402, Upstream Client Id: Not Available, Downstream Address: /216.58.197.227:4143
, Downstream Client Id: %/io.l5d.port/4143/$/io.buoyant.rinet/80/www.google.co.jp
, Trace Id: fc7215ae5f9bbdf4.fc7215ae5f9bbdf4<:fc7215ae5f9bbdf4
```